### PR TITLE
Ucis double

### DIFF
--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -36,6 +36,8 @@ bool process_ucis(uint16_t keycode, keyrecord_t *record) {
                 case KC_ENTER:
                     ucis_finish();
                     return false;
+                default:
+                    return false;
             }
         }
     }

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -37,8 +37,9 @@ static char keycode_to_char(uint16_t keycode) {
 
 bool ucis_add(uint16_t keycode) {
     char c = keycode_to_char(keycode);
-    if (c) {
+    if (c && count < UCIS_MAX_INPUT_LENGTH - 1) {
         input[count++] = c;
+        input[count] = 0;
         return true;
     }
     return false;

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -37,11 +37,14 @@ static char keycode_to_char(uint16_t keycode) {
 
 bool ucis_add(uint16_t keycode) {
     char c = keycode_to_char(keycode);
-    if (c && count < UCIS_MAX_INPUT_LENGTH - 1) {
-        input[count++] = c;
-        input[count]   = 0;
-        return true;
+    if (count < UCIS_MAX_INPUT_LENGTH - 1) {
+        if (c) {
+            input[count++] = c;
+            input[count]   = 0;
+            return true;
+        }
     }
+    tap_code(KC_BACKSPACE);
     return false;
 }
 

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -44,12 +44,12 @@ bool ucis_add(uint16_t keycode) {
             return true;
         }
     }
-    tap_code(KC_BACKSPACE);
     return false;
 }
 
 bool ucis_remove_last(void) {
     if (count) {
+        input[count] = 0;
         count--;
         return true;
     }
@@ -76,10 +76,11 @@ void ucis_finish(void) {
         }
     }
 
+    for (uint8_t j = 0; j <= count; j++) {
+        tap_code(KC_BACKSPACE);
+    }
+
     if (found) {
-        for (uint8_t j = 0; j <= count; j++) {
-            tap_code(KC_BACKSPACE);
-        }
         register_ucis(i);
     }
 
@@ -87,6 +88,10 @@ void ucis_finish(void) {
 }
 
 void ucis_cancel(void) {
+    for (uint8_t i = 0; i <= count; i++) {
+        tap_code(KC_BACKSPACE);
+    }
+
     count  = 0;
     active = false;
 }

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -39,7 +39,7 @@ bool ucis_add(uint16_t keycode) {
     char c = keycode_to_char(keycode);
     if (c && count < UCIS_MAX_INPUT_LENGTH - 1) {
         input[count++] = c;
-        input[count] = 0;
+        input[count]   = 0;
         return true;
     }
     return false;

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -10,10 +10,12 @@ bool    active                       = false;
 char    input[UCIS_MAX_INPUT_LENGTH] = {0};
 
 void ucis_start(void) {
-    count  = 0;
-    active = true;
+    if (!active) {
+        count  = 0;
+        active = true;
 
-    register_unicode(0x2328); // ⌨
+        register_unicode(0x2328); // ⌨
+    }
 }
 
 bool ucis_active(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

If `ucis_activate()` is called twice it produces an spurious ⌨. This fix prevents the reinitialization.

It could be better to cancel or finish the UCIS matching attempt but it can be added by the user. (in fact `ucis_finish` needs a little delay to not mingle the backspaces with the bytes of ⌨ ~10ms or so)

This PR is built on top of #22351 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Prevents multiple initialization of the UCIS system

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
